### PR TITLE
meta sft nft esdt send functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,11 @@
+### [0.0.3](https://github.com/juliancwirko/buildo-begins/releases/tag/v0.0.3) (2022-06-04)
+- added `buildo-begins send-esdt` command for sending ESDT tokens
+- added `buildo-begins send-nft` command for sending NFT tokens
+- added `buildo-begins send-sft` command for sending SFT tokens
+- added `buildo-begins send-meta-esdt` command for sending Meta ESDT tokens
+
 ### [0.0.2](https://github.com/juliancwirko/buildo-begins/releases/tag/v0.0.2) (2022-06-04)
 - initial functionality and configuration
+- added `buildo-begins derive-pem` command for deriving the PEM file, it is then used for all transactions, and it is automatically detected when located in the same directory
+- added `buildo-begins send-egld` command for sending EGLD tokens
+

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -15,6 +15,7 @@ esbuild
       '@elrondnetwork/erdjs-walletcore',
       '@elrondnetwork/erdjs-network-providers',
       'ora',
+      'axios',
     ],
   })
   .catch(() => process.exit(1));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "buildo-begins",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "buildo-begins",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@elrondnetwork/erdjs": "^10.2.5",
         "@elrondnetwork/erdjs-network-providers": "^0.1.5",
         "@elrondnetwork/erdjs-walletcore": "^1.0.0",
+        "axios": "^0.27.2",
         "cosmiconfig": "^7.0.1",
         "ora": "5.4.1",
         "prompts": "^2.4.2"
@@ -167,6 +168,14 @@
         "bignumber.js": "9.0.1",
         "buffer": "6.0.3",
         "json-bigint": "1.0.0"
+      }
+    },
+    "node_modules/@elrondnetwork/erdjs-network-providers/node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/@elrondnetwork/erdjs-walletcore": {
@@ -643,6 +652,11 @@
         "util": "^0.12.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -655,11 +669,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/backslash": {
@@ -906,6 +921,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1010,6 +1036,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dir-glob": {
@@ -1839,6 +1873,19 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2552,6 +2599,25 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -3539,6 +3605,16 @@
         "bignumber.js": "9.0.1",
         "buffer": "6.0.3",
         "json-bigint": "1.0.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.24.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        }
       }
     },
     "@elrondnetwork/erdjs-walletcore": {
@@ -3889,17 +3965,23 @@
         "util": "^0.12.0"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "requires": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "backslash": {
@@ -4075,6 +4157,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4160,6 +4250,11 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -4687,6 +4782,16 @@
         "is-callable": "^1.1.3"
       }
     },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5178,6 +5283,19 @@
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "^14.13.1 || >=16.0.0"
   },
   "types": "build/types",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Elrond blockchain CLI helper tools",
   "main": "build/index.js",
   "bin": {
@@ -48,8 +48,9 @@
     "@elrondnetwork/erdjs": "^10.2.5",
     "@elrondnetwork/erdjs-network-providers": "^0.1.5",
     "@elrondnetwork/erdjs-walletcore": "^1.0.0",
+    "axios": "^0.27.2",
     "cosmiconfig": "^7.0.1",
-    "prompts": "^2.4.2",
-    "ora": "5.4.1"
+    "ora": "5.4.1",
+    "prompts": "^2.4.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,18 @@ import { exit, argv } from 'process';
 import packageJson from '../package.json';
 import { derivePem } from './derive-pem';
 import { sendEgld } from './send-egld';
+import { sendEsdt } from './send-esdt';
+import { sendMetaEsdt } from './send-meta-esdt';
+import { sendNft } from './send-nft';
+import { sendSft } from './send-sft';
 
 const COMMANDS = {
   derivePem: 'derive-pem',
   sendEgld: 'send-egld',
+  sendEsdt: 'send-esdt',
+  sendNft: 'send-nft',
+  sendSft: 'send-sft',
+  sendMetaEsdt: 'send-meta-esdt',
 };
 
 const args = argv;
@@ -26,6 +34,7 @@ if (!command || !Object.values(COMMANDS).includes(command)) {
       ...availableCommands,
       '--version',
       '-v',
+      '--help',
     ].join('\n')}\n`
   );
   exit(9);
@@ -37,6 +46,18 @@ switch (command) {
     break;
   case COMMANDS.sendEgld:
     sendEgld();
+    break;
+  case COMMANDS.sendEsdt:
+    sendEsdt();
+    break;
+  case COMMANDS.sendNft:
+    sendNft();
+    break;
+  case COMMANDS.sendSft:
+    sendSft();
+    break;
+  case COMMANDS.sendMetaEsdt:
+    sendMetaEsdt();
     break;
   default:
     break;

--- a/src/send-egld.ts
+++ b/src/send-egld.ts
@@ -20,7 +20,8 @@ const promptQuestions: PromptObject[] = [
   {
     type: 'text',
     name: 'amount',
-    message: 'Please provide amount of EGLD to send (ex. 1.5 is 1.5 EGLD)\n',
+    message:
+      'Please provide the amount of EGLD to send (ex. 1.5 is 1.5 EGLD)\n',
     validate: (value) =>
       value && !Number.isNaN(value) && Number(value) > 0
         ? true
@@ -53,7 +54,7 @@ export const sendEgld = async () => {
     const tx = new Transaction({
       data,
       gasLimit: 50000 + 1500 * data.length(),
-      receiver: new Address(address),
+      receiver: new Address(address.trim()),
       value: payment,
       chainID: shortChainId[chain],
     });

--- a/src/send-egld.ts
+++ b/src/send-egld.ts
@@ -14,7 +14,7 @@ const promptQuestions: PromptObject[] = [
   {
     type: 'text',
     name: 'address',
-    message: 'Please provide the erd address\n',
+    message: 'Please provide the erd address (receiver)\n',
     validate: (value) => (!value ? 'Required!' : true),
   },
   {

--- a/src/send-esdt.ts
+++ b/src/send-esdt.ts
@@ -1,0 +1,88 @@
+import prompts, { PromptObject } from 'prompts';
+import { exit } from 'process';
+import {
+  TokenPayment,
+  Transaction,
+  ESDTTransferPayloadBuilder,
+  Address,
+} from '@elrondnetwork/erdjs';
+import axios from 'axios';
+
+import { areYouSureAnswer, setup, commonTxOperations } from './utils';
+import { chain, shortChainId, publicApi } from './config';
+
+const promptQuestions: PromptObject[] = [
+  {
+    type: 'text',
+    name: 'address',
+    message: 'Please provide the erd address (receiver)\n',
+    validate: (value) => (!value ? 'Required!' : true),
+  },
+  {
+    type: 'text',
+    name: 'token',
+    message: 'Please provide the ESDT token ticker/id (ex. ABCD-ds323d)\n',
+    validate: (value) => (!value ? 'Required!' : true),
+  },
+  {
+    type: 'text',
+    name: 'amount',
+    message:
+      'Please provide amount of ESDT to send (ex. 1.5 is 1.5 amout of an ESDT token)\n',
+    validate: (value) =>
+      value && !Number.isNaN(value) && Number(value) > 0
+        ? true
+        : `Please provide a number, should be a proper ESDT amount for that specific token, bigger than 0`,
+  },
+];
+
+export const sendEsdt = async () => {
+  try {
+    const { address, amount, token } = await prompts(promptQuestions);
+
+    if (!address || !amount || !token) {
+      console.log('You have to provide the address, token ticker and amount!');
+      exit(9);
+    }
+
+    await areYouSureAnswer();
+
+    const { signer, userAccount, provider } = await setup();
+
+    const esdtOnNetwork = await axios.get<{ decimals: number }>(
+      `${publicApi[chain]}/tokens/${token}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+      }
+    );
+
+    const numDecimals = esdtOnNetwork?.data?.decimals;
+
+    if (numDecimals !== undefined && numDecimals !== null) {
+      const payment = TokenPayment.fungibleFromAmount(
+        token,
+        amount,
+        numDecimals
+      );
+      const data = new ESDTTransferPayloadBuilder().setPayment(payment).build();
+
+      const tx = new Transaction({
+        data,
+        gasLimit: 50000 + 1500 * data.length() + 300000,
+        receiver: new Address(address),
+        chainID: shortChainId[chain],
+      });
+
+      await commonTxOperations(tx, userAccount, signer, provider);
+    } else {
+      console.log(
+        "Can't get the information about the ESDT token on the network. Check configuration and chain type."
+      );
+    }
+  } catch (e) {
+    console.log((e as Error)?.message);
+  }
+};

--- a/src/send-esdt.ts
+++ b/src/send-esdt.ts
@@ -28,7 +28,7 @@ const promptQuestions: PromptObject[] = [
     type: 'text',
     name: 'amount',
     message:
-      'Please provide amount of ESDT to send (ex. 1.5 is 1.5 amout of an ESDT token)\n',
+      'Please provide the amount of ESDT to send (ex. 1.5 is 1.5 amount of an ESDT token)\n',
     validate: (value) =>
       value && !Number.isNaN(value) && Number(value) > 0
         ? true
@@ -50,7 +50,7 @@ export const sendEsdt = async () => {
     const { signer, userAccount, provider } = await setup();
 
     const esdtOnNetwork = await axios.get<{ decimals: number }>(
-      `${publicApi[chain]}/tokens/${token}`,
+      `${publicApi[chain]}/tokens/${token.trim()}`,
       {
         headers: {
           'Content-Type': 'application/json',
@@ -72,7 +72,7 @@ export const sendEsdt = async () => {
       const tx = new Transaction({
         data,
         gasLimit: 50000 + 1500 * data.length() + 300000,
-        receiver: new Address(address),
+        receiver: new Address(address.trim()),
         chainID: shortChainId[chain],
       });
 

--- a/src/send-meta-esdt.ts
+++ b/src/send-meta-esdt.ts
@@ -29,7 +29,7 @@ const promptQuestions: PromptObject[] = [
     type: 'text',
     name: 'amount',
     message:
-      'Please provide amount of Meta ESDT to send (ex. 0.1 is 0.1 amout of Meta ESDT token)\n',
+      'Please provide the amount of Meta ESDT to send (ex. 0.1 is 0.1 amount of Meta ESDT token)\n',
     validate: (value) =>
       value && !Number.isNaN(value) && Number(value) > 0
         ? true
@@ -54,7 +54,7 @@ export const sendMetaEsdt = async () => {
       decimals: number;
       nonce: number;
       ticker: string;
-    }>(`${publicApi[chain]}/nfts/${token}`, {
+    }>(`${publicApi[chain]}/nfts/${token.trim()}`, {
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
@@ -81,7 +81,7 @@ export const sendMetaEsdt = async () => {
       );
       const data = new ESDTNFTTransferPayloadBuilder()
         .setPayment(payment)
-        .setDestination(new Address(address))
+        .setDestination(new Address(address.trim()))
         .build();
 
       const tx = new Transaction({

--- a/src/send-meta-esdt.ts
+++ b/src/send-meta-esdt.ts
@@ -1,0 +1,104 @@
+import prompts, { PromptObject } from 'prompts';
+import { exit } from 'process';
+import {
+  TokenPayment,
+  Transaction,
+  ESDTNFTTransferPayloadBuilder,
+  Address,
+} from '@elrondnetwork/erdjs';
+import axios from 'axios';
+
+import { areYouSureAnswer, setup, commonTxOperations } from './utils';
+import { chain, shortChainId, publicApi } from './config';
+
+const promptQuestions: PromptObject[] = [
+  {
+    type: 'text',
+    name: 'address',
+    message: 'Please provide the erd address (receiver)\n',
+    validate: (value) => (!value ? 'Required!' : true),
+  },
+  {
+    type: 'text',
+    name: 'token',
+    message:
+      'Please provide the Meta ESDT token ticker/id (ex. ABCD-ds323d-0d)\n',
+    validate: (value) => (!value ? 'Required!' : true),
+  },
+  {
+    type: 'text',
+    name: 'amount',
+    message:
+      'Please provide amount of Meta ESDT to send (ex. 0.1 is 0.1 amout of Meta ESDT token)\n',
+    validate: (value) =>
+      value && !Number.isNaN(value) && Number(value) > 0
+        ? true
+        : `Please provide a number, should be a proper Meta ESDT amount for that specific token, bigger than 0`,
+  },
+];
+
+export const sendMetaEsdt = async () => {
+  try {
+    const { address, amount, token } = await prompts(promptQuestions);
+
+    if (!address || !amount || !token) {
+      console.log('You have to provide the address, token ticker and amount!');
+      exit(9);
+    }
+
+    await areYouSureAnswer();
+
+    const { signer, userAccount, provider } = await setup();
+
+    const metaEsdtOnNetwork = await axios.get<{
+      decimals: number;
+      nonce: number;
+      ticker: string;
+    }>(`${publicApi[chain]}/nfts/${token}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    });
+
+    const numDecimals = metaEsdtOnNetwork?.data?.decimals;
+    const nonce = metaEsdtOnNetwork?.data?.nonce;
+    const collectionTicker = metaEsdtOnNetwork?.data?.ticker;
+
+    if (
+      numDecimals !== undefined &&
+      numDecimals !== null &&
+      nonce !== undefined &&
+      nonce !== null &&
+      collectionTicker !== undefined &&
+      collectionTicker !== null
+    ) {
+      const payment = TokenPayment.metaEsdtFromAmount(
+        collectionTicker,
+        nonce,
+        amount,
+        numDecimals
+      );
+      const data = new ESDTNFTTransferPayloadBuilder()
+        .setPayment(payment)
+        .setDestination(new Address(address))
+        .build();
+
+      const tx = new Transaction({
+        nonce,
+        data,
+        gasLimit: 50000 + 1500 * data.length() + 1000000,
+        receiver: signer.getAddress(), // Same as sender address!
+        chainID: shortChainId[chain],
+      });
+
+      await commonTxOperations(tx, userAccount, signer, provider);
+    } else {
+      console.log(
+        "Can't get the information about the Meta ESDT token on the network. Check configuration and chain type."
+      );
+    }
+  } catch (e) {
+    console.log((e as Error)?.message);
+  }
+};

--- a/src/send-nft.ts
+++ b/src/send-nft.ts
@@ -1,0 +1,86 @@
+import prompts, { PromptObject } from 'prompts';
+import { exit } from 'process';
+import {
+  TokenPayment,
+  Transaction,
+  ESDTNFTTransferPayloadBuilder,
+  Address,
+} from '@elrondnetwork/erdjs';
+import axios from 'axios';
+
+import { areYouSureAnswer, setup, commonTxOperations } from './utils';
+import { chain, shortChainId, publicApi } from './config';
+
+const promptQuestions: PromptObject[] = [
+  {
+    type: 'text',
+    name: 'address',
+    message: 'Please provide the erd address (receiver)\n',
+    validate: (value) => (!value ? 'Required!' : true),
+  },
+  {
+    type: 'text',
+    name: 'token',
+    message: 'Please provide the NFT token id (ex. ABCD-ds323d-0d)\n',
+    validate: (value) => (!value ? 'Required!' : true),
+  },
+];
+
+export const sendNft = async () => {
+  try {
+    const { address, token } = await prompts(promptQuestions);
+
+    if (!address || !token) {
+      console.log(
+        'You have to provide the address and NFT token id and amount!'
+      );
+      exit(9);
+    }
+
+    await areYouSureAnswer();
+
+    const { signer, userAccount, provider } = await setup();
+
+    const nftOnNetwork = await axios.get<{ nonce: number; ticker: string }>(
+      `${publicApi[chain]}/nfts/${token}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+      }
+    );
+
+    const nonce = nftOnNetwork?.data?.nonce;
+    const collectionTicker = nftOnNetwork?.data?.ticker;
+
+    if (
+      nonce !== undefined &&
+      nonce !== null &&
+      collectionTicker !== undefined &&
+      collectionTicker !== null
+    ) {
+      const payment = TokenPayment.nonFungible(collectionTicker, nonce);
+      const data = new ESDTNFTTransferPayloadBuilder()
+        .setPayment(payment)
+        .setDestination(new Address(address))
+        .build();
+
+      const tx = new Transaction({
+        nonce,
+        data,
+        gasLimit: 50000 + 1500 * data.length() + 1000000,
+        receiver: signer.getAddress(), // Same as sender address!
+        chainID: shortChainId[chain],
+      });
+
+      await commonTxOperations(tx, userAccount, signer, provider);
+    } else {
+      console.log(
+        "Can't get the information about the NFT token on the network. Check configuration and chain type."
+      );
+    }
+  } catch (e) {
+    console.log((e as Error)?.message);
+  }
+};

--- a/src/send-nft.ts
+++ b/src/send-nft.ts
@@ -42,7 +42,7 @@ export const sendNft = async () => {
     const { signer, userAccount, provider } = await setup();
 
     const nftOnNetwork = await axios.get<{ nonce: number; ticker: string }>(
-      `${publicApi[chain]}/nfts/${token}`,
+      `${publicApi[chain]}/nfts/${token.trim()}`,
       {
         headers: {
           'Content-Type': 'application/json',
@@ -63,7 +63,7 @@ export const sendNft = async () => {
       const payment = TokenPayment.nonFungible(collectionTicker, nonce);
       const data = new ESDTNFTTransferPayloadBuilder()
         .setPayment(payment)
-        .setDestination(new Address(address))
+        .setDestination(new Address(address.trim()))
         .build();
 
       const tx = new Transaction({

--- a/src/send-sft.ts
+++ b/src/send-sft.ts
@@ -1,0 +1,98 @@
+import prompts, { PromptObject } from 'prompts';
+import { exit } from 'process';
+import {
+  TokenPayment,
+  Transaction,
+  ESDTNFTTransferPayloadBuilder,
+  Address,
+} from '@elrondnetwork/erdjs';
+import axios from 'axios';
+
+import { areYouSureAnswer, setup, commonTxOperations } from './utils';
+import { chain, shortChainId, publicApi } from './config';
+
+const promptQuestions: PromptObject[] = [
+  {
+    type: 'text',
+    name: 'address',
+    message: 'Please provide the erd address (receiver)\n',
+    validate: (value) => (!value ? 'Required!' : true),
+  },
+  {
+    type: 'text',
+    name: 'token',
+    message: 'Please provide the SFT token id (ex. ABCD-ds323d-0d)\n',
+    validate: (value) => (!value ? 'Required!' : true),
+  },
+  {
+    type: 'text',
+    name: 'amount',
+    message:
+      'Please provide amount of SFT to send (ex. 1 is 1 amout of an SFT token)\n',
+    validate: (value) =>
+      value && !Number.isNaN(value) && Number(value) > 0
+        ? true
+        : `Please provide a number, should be a proper SFT amount for that specific token, bigger than 0`,
+  },
+];
+
+export const sendSft = async () => {
+  try {
+    const { address, token, amount } = await prompts(promptQuestions);
+
+    if (!address || !token || !amount) {
+      console.log('You have to provide the address, SFT token id and amount!');
+      exit(9);
+    }
+
+    await areYouSureAnswer();
+
+    const { signer, userAccount, provider } = await setup();
+
+    const sftOnNetwork = await axios.get<{ nonce: number; ticker: string }>(
+      `${publicApi[chain]}/nfts/${token}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+      }
+    );
+
+    const nonce = sftOnNetwork?.data?.nonce;
+    const collectionTicker = sftOnNetwork?.data?.ticker;
+
+    if (
+      nonce !== undefined &&
+      nonce !== null &&
+      collectionTicker !== undefined &&
+      collectionTicker !== null
+    ) {
+      const payment = TokenPayment.semiFungible(
+        collectionTicker,
+        nonce,
+        amount
+      );
+      const data = new ESDTNFTTransferPayloadBuilder()
+        .setPayment(payment)
+        .setDestination(new Address(address))
+        .build();
+
+      const tx = new Transaction({
+        nonce,
+        data,
+        gasLimit: 50000 + 1500 * data.length() + 1000000,
+        receiver: signer.getAddress(), // Same as sender address!
+        chainID: shortChainId[chain],
+      });
+
+      await commonTxOperations(tx, userAccount, signer, provider);
+    } else {
+      console.log(
+        "Can't get the information about the SFT token on the network. Check configuration and chain type."
+      );
+    }
+  } catch (e) {
+    console.log((e as Error)?.message);
+  }
+};

--- a/src/send-sft.ts
+++ b/src/send-sft.ts
@@ -28,7 +28,7 @@ const promptQuestions: PromptObject[] = [
     type: 'text',
     name: 'amount',
     message:
-      'Please provide amount of SFT to send (ex. 1 is 1 amout of an SFT token)\n',
+      'Please provide the amount of SFT to send (ex. 1 is 1 amount of an SFT token)\n',
     validate: (value) =>
       value && !Number.isNaN(value) && Number(value) > 0
         ? true
@@ -50,7 +50,7 @@ export const sendSft = async () => {
     const { signer, userAccount, provider } = await setup();
 
     const sftOnNetwork = await axios.get<{ nonce: number; ticker: string }>(
-      `${publicApi[chain]}/nfts/${token}`,
+      `${publicApi[chain]}/nfts/${token.trim()}`,
       {
         headers: {
           'Content-Type': 'application/json',
@@ -75,7 +75,7 @@ export const sendSft = async () => {
       );
       const data = new ESDTNFTTransferPayloadBuilder()
         .setPayment(payment)
-        .setDestination(new Address(address))
+        .setDestination(new Address(address.trim()))
         .build();
 
       const tx = new Transaction({


### PR DESCRIPTION
- added `buildo-begins send-esdt` command for sending ESDT tokens
- added `buildo-begins send-nft` command for sending NFT tokens
- added `buildo-begins send-sft` command for sending SFT tokens
- added `buildo-begins send-meta-esdt` command for sending Meta ESDT tokens

Not keeping the DRY, but it isn't so bad, and I think it is good to have it more readable for learning purposes. And also, it can be simpler to decouple the functionality if someone wants to build something custom.