### PR TITLE
pause and freeze esdt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,23 @@
-### [0.2.0](https://github.com/juliancwirko/buildo-begins/releases/tag/v0.2.0) (2022-06-16)
+### [0.2.1](https://github.com/ElrondDevGuild/buildo-begins/releases/tag/v0.2.1) (2022-06-20)
+- added `buildo-begins pause-unpause-esdt` - a command for pause or unpause all transactions of the token (of course you need `canPause` role on such ESDT)
+- added `buildo-begins freeze-unfreeze-esdt` - a command to freeze/unfreeze the token balance in a specific account, preventing transfers to and from that account (of course you need `canFreeze` role on such ESDT)
+
+### [0.2.0](https://github.com/ElrondDevGuild/buildo-begins/releases/tag/v0.2.0) (2022-06-16)
 - added `buildo-begins herotag` - a command for creating Elrond herotag (dns) and checking the address of the existing one
 
-### [0.1.0](https://github.com/juliancwirko/buildo-begins/releases/tag/v0.1.0) (2022-06-12)
+### [0.1.0](https://github.com/ElrondDevGuild/buildo-begins/releases/tag/v0.1.0) (2022-06-12)
 - added `buildo-begins issue-esdt` command for issuing new ESDT tokens
 - added `buildo-begins set-special-roles-esdt` command for setting and unsetting special ESDT roles - local mint, and local burn
 - added `buildo-begins mint-burn-esdt` command for minting or burning ESDT token supply (requires special roles from the command above)
 - more operations on ESDT soon. Stay tuned!
 
-### [0.0.3](https://github.com/juliancwirko/buildo-begins/releases/tag/v0.0.3) (2022-06-04)
+### [0.0.3](https://github.com/ElrondDevGuild/buildo-begins/releases/tag/v0.0.3) (2022-06-04)
 - added `buildo-begins send-esdt` command for sending ESDT tokens
 - added `buildo-begins send-nft` command for sending NFT tokens
 - added `buildo-begins send-sft` command for sending SFT tokens
 - added `buildo-begins send-meta-esdt` command for sending Meta ESDT tokens
 
-### [0.0.2](https://github.com/juliancwirko/buildo-begins/releases/tag/v0.0.2) (2022-06-04)
+### [0.0.2](https://github.com/ElrondDevGuild/buildo-begins/releases/tag/v0.0.2) (2022-06-04)
 - initial functionality and configuration
 - added `buildo-begins derive-pem` command for deriving the PEM file, it is then used for all transactions, and it is automatically detected when located in the same directory
 - added `buildo-begins send-egld` command for sending EGLD tokens
-

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ For now, the first version gives you basic stuff. But there will be much more:
 6. `buildo-begins send-meta-esdt` - send Meta ESDT tokens
 7. `buildo-begins issue-esdt` - issue new ESDT token
 8. `buildo-begins set-special-roles-esdt` - set/unset special ESDT roles
-9. `buildo-begins mint-burn-esdt` - mint/burn the ESDT token supply (requires special roles)
-10. `buildo-begins herotag` - create a herotag and assign it to addres and check addresses of existing ones
+9. `buildo-begins mint-burn-esdt` - mint/burn the ESDT token supply (requires `canMint`, `canBurn` roles)
+10. `buildo-begins pause-unpause-esdt` - pause/unpause all transactions of the token (requires `canPause` role)
+11. `buildo-begins freeze-unfreeze-esdt` - freeze/unfreeze the token balance in a specific account, preventing transfers to and from that account (requires `canFreeze` role)
+12. `buildo-begins herotag` - create a herotag and assign it to addres and check addresses of existing ones
 
 What is awesome here is that you don't have to worry about proper nonce, decimal places, or differentiation between the NFT token id and collection ticker. The maximum amount of arguments will always be the address, token id, and amount. It will differ for each type, but these are maximum.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "^14.13.1 || >=16.0.0"
   },
   "types": "build/types",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Elrond blockchain CLI helper tools",
   "main": "build/index.js",
   "bin": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,7 @@ export const esdtTokenProperties = [
 export const esdtTokenSpecialRoles = ['ESDTRoleLocalBurn', 'ESDTRoleLocalMint'];
 
 // Build in address for token issuance
-export const builtInTokenIssuanceSC =
+export const builtInEsdtSC =
   'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u';
 
 // Predefined one time payment for token issuance (EGLD amount)

--- a/src/esdt/issue-esdt.ts
+++ b/src/esdt/issue-esdt.ts
@@ -18,7 +18,7 @@ import {
   chain,
   shortChainId,
   issueTokenPayment,
-  builtInTokenIssuanceSC,
+  builtInEsdtSC,
   esdtOpertationsGasLimit,
   esdtTokenProperties,
 } from '../config';
@@ -124,7 +124,7 @@ export const issueEsdt = async () => {
     const tx = new Transaction({
       data,
       gasLimit: esdtOpertationsGasLimit,
-      receiver: new Address(builtInTokenIssuanceSC.trim()),
+      receiver: new Address(builtInEsdtSC.trim()),
       value: payment,
       chainID: shortChainId[chain],
     });

--- a/src/esdt/pause-unpause.ts
+++ b/src/esdt/pause-unpause.ts
@@ -1,0 +1,71 @@
+import prompts, { PromptObject } from 'prompts';
+import { exit } from 'process';
+import {
+  Transaction,
+  BytesValue,
+  ContractCallPayloadBuilder,
+  ContractFunction,
+  TypedValue,
+  Address,
+} from '@elrondnetwork/erdjs';
+
+import { areYouSureAnswer, setup, commonTxOperations } from '../utils';
+import {
+  chain,
+  shortChainId,
+  esdtOpertationsGasLimit,
+  builtInEsdtSC,
+} from '../config';
+
+const promptQuestions: PromptObject[] = [
+  {
+    type: 'select',
+    name: 'type',
+    message: 'Do you want to pause or unpause all transactions of the token?\n',
+    validate: (value) => (!value ? 'Required!' : true),
+    choices: [
+      { title: 'Pause', value: 'pause' },
+      { title: 'Unpause', value: 'unpause' },
+    ],
+  },
+  {
+    type: 'text',
+    name: 'ticker',
+    message: 'Please provide the token ticker\n',
+    validate: (value) => (!value ? 'Required!' : true),
+  },
+];
+
+export const pauseUnpauseEsdt = async () => {
+  try {
+    const { ticker, type } = await prompts(promptQuestions);
+
+    if (!ticker) {
+      console.log('You have to provide the ticker!');
+      exit(9);
+    }
+
+    await areYouSureAnswer();
+
+    const { signer, userAccount, provider } = await setup();
+
+    const args: TypedValue[] = [BytesValue.fromUTF8(ticker)];
+
+    const data = new ContractCallPayloadBuilder()
+      .setFunction(new ContractFunction(type === 'pause' ? 'pause' : 'unPause'))
+      .setArgs(args)
+      .build();
+
+    const tx = new Transaction({
+      data,
+      gasLimit: esdtOpertationsGasLimit,
+      receiver: new Address(builtInEsdtSC),
+      value: 0,
+      chainID: shortChainId[chain],
+    });
+
+    await commonTxOperations(tx, userAccount, signer, provider);
+  } catch (e) {
+    console.log((e as Error)?.message);
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { sendNft } from './nft/send-nft';
 import { sendSft } from './sft/send-sft';
 import { sendMetaEsdt } from './meta-esdt/send-meta-esdt';
 import { herotag } from './herotag';
+import { pauseUnpauseEsdt } from './esdt/pause-unpause';
+import { freezeUnfreezeEsdt } from './esdt/freeze-unfreeze-esdt';
 
 const COMMANDS = {
   derivePem: 'derive-pem',
@@ -25,6 +27,8 @@ const COMMANDS = {
   mintBurnEsdt: 'mint-burn-esdt',
   setSpecialRolesEsdt: 'set-special-roles-esdt',
   herotag: 'herotag',
+  pauseUnpauseEsdt: 'pause-unpause-esdt',
+  freezeUnfreezeEsdt: 'freeze-unfreeze-esdt',
 };
 
 const args = argv;
@@ -79,6 +83,12 @@ switch (command) {
     break;
   case COMMANDS.herotag:
     herotag();
+    break;
+  case COMMANDS.pauseUnpauseEsdt:
+    pauseUnpauseEsdt();
+    break;
+  case COMMANDS.freezeUnfreezeEsdt:
+    freezeUnfreezeEsdt();
     break;
   default:
     break;


### PR DESCRIPTION
- added `buildo-begins pause-unpause-esdt` - a command for pause or unpause all transactions of the token (of course, you need the `canPause` role on such ESDT)
- added `buildo-begins freeze-unfreeze-esdt` - a command to freeze/unfreeze the token balance in a specific account, preventing transfers to and from that account (of course, you need the `canFreeze` role on such ESDT)